### PR TITLE
Fixes [Issue #93] semantic major version of Laravel

### DIFF
--- a/src/CloudinaryServiceProvider.php
+++ b/src/CloudinaryServiceProvider.php
@@ -101,7 +101,8 @@ class CloudinaryServiceProvider extends ServiceProvider
     
     protected function getComponentName($componentName) 
     {
-       if( (int)$this->app->version()[0] <= 6 ) {
+       $version = explode(".", $this->app->version());
+       if( (int)$version[0] <= 6 ) {
           $componentName = str_replace("-", "_", $componentName);
        }
         


### PR DESCRIPTION
Current code only extracts the first digit to retrieve the major version of Laravel, but this is incorrect as of Laravel version 10: the major version now has 2 digits.