### PR TITLE
update the the component name in the docs to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,12 +291,12 @@ $options = [
 ]
 
 $page->attachMedia($file, $options);   // Example of $file is $request->file('file');
-
+``
 ```
 
 ## **Upload Files Via An Upload Widget**:
 
-Use the `x-cld-upload-button` Blade upload button component that ships with this Package like so:
+Use the `x-cld_upload_button` Blade upload button component that ships with this Package like so:
 ```
 <!DOCTYPE html>
 <html>
@@ -305,9 +305,9 @@ Use the `x-cld-upload-button` Blade upload button component that ships with this
         @cloudinaryJS
     </head>
     <body>
-        <x-cld-upload-button>
+        <x-cld_upload_button>
             Upload Files
-        </x-cld-upload-button>
+        </x-cld_upload_button>
     </body>
 </html>
 ````


### PR DESCRIPTION
After PR https://github.com/cloudinary-devs/cloudinary-laravel/pull/94 was merged, this means the documentation is now wrong as the component is called cld_upload_button rather than cld-upload-button. this PR updates the docs